### PR TITLE
Fix Garden of Eden logo background and add sponsor images

### DIFF
--- a/js/sponsors.js
+++ b/js/sponsors.js
@@ -29,7 +29,7 @@ const SponsorsCarousel = (() => {
     },
     {
       name: 'The Garden of Eden',
-      image: '/assets/images/sponsors/garden.jpg',
+      image: '/assets/images/sponsors/garden.png',
       url: 'https://www.instagram.com/thegardenofeden1999/',
       description: 'Community garden and sustainable living'
     },

--- a/pages/vendors/sponsors.html
+++ b/pages/vendors/sponsors.html
@@ -330,7 +330,7 @@
         <div class="sponsor-logos">
           <div class="sponsor-card gold">
             <div class="sponsor-logo">
-              <div class="logo-placeholder">Gemini Capital Group</div>
+              <img src="/assets/images/sponsors/GeminiCG.png" alt="Gemini Capital Group">
             </div>
             <h4 class="sponsor-name">Gemini Capital Group</h4>
             <p class="sponsor-description">Premier investment partner supporting Arkansas communities</p>
@@ -344,14 +344,14 @@
         <div class="sponsor-logos">
           <div class="sponsor-card silver">
             <div class="sponsor-logo">
-              <div class="logo-placeholder">Beard & Lady Inn</div>
+              <img src="/assets/images/sponsors/beard.jpg" alt="Beard & Lady Inn">
             </div>
             <h4 class="sponsor-name">Beard & Lady Inn</h4>
             <p class="sponsor-description">Historic venue and heart of the festival</p>
           </div>
           <div class="sponsor-card silver">
             <div class="sponsor-logo">
-              <div class="logo-placeholder">The Garden of Eden</div>
+              <img src="/assets/images/sponsors/garden.png" alt="The Garden of Eden">
             </div>
             <h4 class="sponsor-name">The Garden of Eden</h4>
             <p class="sponsor-description">Supporting local agriculture and sustainability</p>


### PR DESCRIPTION
## Summary
- Use transparent Garden of Eden logo across the site
- Display Beard & Lady Inn, Garden of Eden, and Gemini Capital Group logos on sponsor tiers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893549c65788325bd41a181ae5c3d87