### PR TITLE
feat: add BPSAI credit link to footer

### DIFF
--- a/components/footer.html
+++ b/components/footer.html
@@ -51,6 +51,7 @@
     </div>
     <div class="footer-bottom">
       <p class="footer-text">&copy; 2025 Boston Mountains Pawpaw Festival · All rights reserved</p>
+      <a href="https://bpsaisoftware.com/" target="_blank" rel="noopener noreferrer" class="footer-powered">Powered by BPSAI</a>
     </div>
   </div>
 </footer>

--- a/css/components/footer.css
+++ b/css/components/footer.css
@@ -198,7 +198,25 @@
 .footer-bottom {
   padding-top: 2rem;
   border-top: 1px solid rgba(255, 255, 255, 0.1);
-  text-align: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  text-align: left;
+}
+
+.footer-powered {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--color-white);
+  opacity: 0.6;
+  text-decoration: none;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.footer-powered:hover {
+  opacity: 1;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- highlight BPSAI in footer with small futuristic credit link
- style footer layout for right-aligned credit

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68935ef4c4b08325b03acfeae229ce6c